### PR TITLE
Add deployment documentation

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,0 +1,20 @@
+name: Deploy Production
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: netlify/actions/cli@v4
+        with:
+          args: deploy --dir=dist --prod
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PROD_SITE_ID }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,0 +1,20 @@
+name: Deploy Staging
+on:
+  push:
+    branches: [stage]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: netlify/actions/cli@v4
+        with:
+          args: deploy --dir=dist --alias=staging
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_STAGING_SITE_ID }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # Global Energia
+
+This repository contains the React application for Global Energia.
+
+## Local development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+To preview a build locally:
+
+```bash
+npm run build
+npm run preview
+```
+
+## Environments
+
+Deployments are handled by Netlify using GitHub Actions.
+
+- **Staging** – pushes to the `stage` branch are deployed to a staging site.
+- **Production** – pushes to the `main` branch are deployed to <https://globalenergia.netlify.app/>.
+
+The staging URL uses a Netlify alias, typically `https://staging--<site>.netlify.app`.
+
+You can also trigger manual deployments locally:
+
+```bash
+npm run deploy:stage    # deploys current build to the staging URL
+npm run deploy:prod     # deploys to production
+```
+
+Configure the following repository secrets so the workflows can deploy:
+
+- `NETLIFY_AUTH_TOKEN`
+- `NETLIFY_STAGING_SITE_ID`
+- `NETLIFY_PROD_SITE_ID`

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[context.production.environment]
+  NODE_ENV = "production"
+
+[context.staging.environment]
+  NODE_ENV = "staging"

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "global-energia",
   "version": "0.1.0",
   "private": true,
-  "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
-  },
+    "scripts": {
+      "dev": "vite",
+      "build": "vite build",
+      "preview": "vite preview",
+      "deploy:stage": "netlify deploy --dir=dist --alias=staging",
+      "deploy:prod": "netlify deploy --dir=dist --prod"
+    },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- document preview and deployment commands in README
- provide Netlify deploy scripts for staging and production

## Testing
- `npm ci` *(fails: unable to reach registry)*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_6872babdc8848323b57b3d58268d4b28